### PR TITLE
Fix/reduce icon size

### DIFF
--- a/.changeset/khaki-bobcats-deliver.md
+++ b/.changeset/khaki-bobcats-deliver.md
@@ -1,0 +1,7 @@
+---
+"@wonderflow/config": major
+"@wonderflow/react-components": minor
+"@wonderflow/tokens": minor
+---
+
+Replace icon size token 14 with 12

--- a/package-lock.json
+++ b/package-lock.json
@@ -20641,6 +20641,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -21080,6 +21081,7 @@
     },
     "node_modules/camel-case": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pascal-case": "^3.1.2",
@@ -21142,6 +21144,7 @@
     },
     "node_modules/capital-case": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -21204,6 +21207,7 @@
     },
     "node_modules/change-case": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camel-case": "^4.1.2",
@@ -21986,6 +21990,7 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -22039,6 +22044,7 @@
     },
     "node_modules/constant-case": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -24087,6 +24093,7 @@
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -26554,6 +26561,7 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -26774,6 +26782,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -27336,6 +27345,7 @@
     },
     "node_modules/header-case": {
       "version": "2.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "capital-case": "^1.0.4",
@@ -27722,6 +27732,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -28906,6 +28917,7 @@
     },
     "node_modules/jsonc-parser": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -29468,6 +29480,7 @@
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -30207,6 +30220,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -31516,6 +31530,7 @@
     },
     "node_modules/no-case": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lower-case": "^2.0.2",
@@ -35074,6 +35089,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -35365,6 +35381,7 @@
     },
     "node_modules/param-case": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -35464,6 +35481,7 @@
     },
     "node_modules/pascal-case": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -35484,6 +35502,7 @@
     },
     "node_modules/path-case": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -35505,6 +35524,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -39265,6 +39285,7 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -39885,6 +39906,7 @@
     },
     "node_modules/sentence-case": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
@@ -40408,6 +40430,7 @@
     },
     "node_modules/snake-case": {
       "version": "3.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
@@ -41600,6 +41623,7 @@
     },
     "node_modules/style-dictionary": {
       "version": "3.1.1",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -41621,6 +41645,7 @@
     },
     "node_modules/style-dictionary/node_modules/commander": {
       "version": "5.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -41628,6 +41653,7 @@
     },
     "node_modules/style-dictionary/node_modules/fs-extra": {
       "version": "8.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -41640,6 +41666,7 @@
     },
     "node_modules/style-dictionary/node_modules/jsonfile": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -41647,6 +41674,7 @@
     },
     "node_modules/style-dictionary/node_modules/universalify": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -42681,6 +42709,7 @@
     },
     "node_modules/tinycolor2": {
       "version": "1.4.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -43760,6 +43789,7 @@
     },
     "node_modules/upper-case": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -43767,6 +43797,7 @@
     },
     "node_modules/upper-case-first": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -45069,6 +45100,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -45238,17 +45270,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "packages/config/node_modules/@wonderflow/tokens": {
-      "version": "1.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "rimraf": "^3.0.2",
-        "style-dictionary": "^3.0.3"
-      }
-    },
     "packages/icons": {
       "name": "@wonderflow/icons",
-      "version": "1.0.3",
+      "version": "4.0.0",
       "license": "MIT",
       "devDependencies": {
         "cpy-cli": "3.1.1",
@@ -59540,13 +59564,6 @@
         "@types/flat": {
           "version": "5.0.2",
           "dev": true
-        },
-        "@wonderflow/tokens": {
-          "version": "1.3.7",
-          "requires": {
-            "rimraf": "^3.0.2",
-            "style-dictionary": "^3.0.3"
-          }
         }
       }
     },
@@ -60669,6 +60686,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -60974,6 +60992,7 @@
     },
     "camel-case": {
       "version": "4.1.2",
+      "dev": true,
       "requires": {
         "pascal-case": "^3.1.2",
         "tslib": "^2.0.3"
@@ -61014,6 +61033,7 @@
     },
     "capital-case": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -61051,6 +61071,7 @@
     },
     "change-case": {
       "version": "4.1.2",
+      "dev": true,
       "requires": {
         "camel-case": "^4.1.2",
         "capital-case": "^1.0.4",
@@ -61579,7 +61600,8 @@
       "dev": true
     },
     "concat-map": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -61626,6 +61648,7 @@
     },
     "constant-case": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -63029,6 +63052,7 @@
     },
     "dot-case": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -64724,7 +64748,8 @@
       }
     },
     "fs.realpath": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
@@ -64862,6 +64887,7 @@
     },
     "glob": {
       "version": "7.2.0",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -65216,6 +65242,7 @@
     },
     "header-case": {
       "version": "2.0.4",
+      "dev": true,
       "requires": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
@@ -65450,6 +65477,7 @@
     },
     "inflight": {
       "version": "1.0.6",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -66152,7 +66180,8 @@
       }
     },
     "jsonc-parser": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -66524,6 +66553,7 @@
     },
     "lower-case": {
       "version": "2.0.2",
+      "dev": true,
       "requires": {
         "tslib": "^2.0.3"
       }
@@ -66992,6 +67022,7 @@
     },
     "minimatch": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -67795,6 +67826,7 @@
     },
     "no-case": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -70315,6 +70347,7 @@
     },
     "once": {
       "version": "1.4.0",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -70501,6 +70534,7 @@
     },
     "param-case": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -70571,6 +70605,7 @@
     },
     "pascal-case": {
       "version": "3.1.2",
+      "dev": true,
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -70585,6 +70620,7 @@
     },
     "path-case": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -70599,7 +70635,8 @@
       "dev": true
     },
     "path-is-absolute": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -72888,6 +72925,7 @@
     },
     "rimraf": {
       "version": "3.0.2",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -73313,6 +73351,7 @@
     },
     "sentence-case": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
@@ -73675,6 +73714,7 @@
     },
     "snake-case": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -74519,6 +74559,7 @@
     },
     "style-dictionary": {
       "version": "3.1.1",
+      "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "change-case": "^4.1.2",
@@ -74532,10 +74573,12 @@
       },
       "dependencies": {
         "commander": {
-          "version": "5.1.0"
+          "version": "5.1.0",
+          "dev": true
         },
         "fs-extra": {
           "version": "8.1.0",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -74544,12 +74587,14 @@
         },
         "jsonfile": {
           "version": "4.0.0",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
         },
         "universalify": {
-          "version": "0.1.2"
+          "version": "0.1.2",
+          "dev": true
         }
       }
     },
@@ -75218,7 +75263,8 @@
       "version": "0.3.0"
     },
     "tinycolor2": {
-      "version": "1.4.2"
+      "version": "1.4.2",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
@@ -75885,12 +75931,14 @@
     },
     "upper-case": {
       "version": "2.0.2",
+      "dev": true,
       "requires": {
         "tslib": "^2.0.3"
       }
     },
     "upper-case-first": {
       "version": "2.0.2",
+      "dev": true,
       "requires": {
         "tslib": "^2.0.3"
       }
@@ -76761,7 +76809,8 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/packages/config/src/postcss/config.ts
+++ b/packages/config/src/postcss/config.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable global-require */
 import jsonTokens from '@wonderflow/tokens/platforms/web/tokens.json'
 import postcssMixins from 'postcss-mixins'
 import flatten from 'flat'

--- a/packages/react-components/src/components/button/button.tsx
+++ b/packages/react-components/src/components/button/button.tsx
@@ -83,7 +83,7 @@ export const Button = forwardRef((
   const iconSize = {
     big: 24,
     regular: 16,
-    small: 14
+    small: 12
   }
 
   return (

--- a/packages/react-components/src/components/card/card.tsx
+++ b/packages/react-components/src/components/card/card.tsx
@@ -100,9 +100,9 @@ export const Card = forwardRef(({
         )}
 
         {right && (
-          <Stack className={styles.Right}>
+          <div className={styles.Right}>
             {right}
-          </Stack>
+          </div>
         )}
       </Stack>
     </Wrapper>

--- a/packages/react-components/src/components/chip/chip.tsx
+++ b/packages/react-components/src/components/chip/chip.tsx
@@ -33,10 +33,10 @@ export const Chip = forwardRef<HTMLSpanElement, ChipProps>(({
 }, forwardedRef) => {
   const properties = {
     small: {
-      iconSize: 14
+      iconSize: 12
     },
     regular: {
-      iconSize: 14
+      iconSize: 12
     },
     big: {
       iconSize: 16

--- a/packages/react-components/src/components/disclosure/disclosure.module.css
+++ b/packages/react-components/src/components/disclosure/disclosure.module.css
@@ -14,7 +14,8 @@
   }
 
   &[data-disclosure-dimension='small'] {
-    --icon-size: env(--icon-size-14);
+    --icon-top-offset: calc(var(--icon-size) / 1.5);
+    --icon-size: env(--icon-size-12);
   }
 
   &[data-disclosure-dimension='regular'] {

--- a/packages/react-components/src/components/disclosure/disclosure.tsx
+++ b/packages/react-components/src/components/disclosure/disclosure.tsx
@@ -74,7 +74,7 @@ export const Disclosure = forwardRef<HTMLDetailsElement, DisclosureProps>(({
   const sizes = {
     small: {
       summary: 16,
-      icon: 14
+      icon: 12
     },
     regular: {
       summary: 18,

--- a/packages/react-components/src/components/drawer/drawer.stories.tsx
+++ b/packages/react-components/src/components/drawer/drawer.stories.tsx
@@ -77,7 +77,7 @@ const DrawerShell: ComponentStory<typeof Drawer> = ({ children, ...args }) => {
       Quibusdam aliquam ipsam praesentium? Eaque officiis officia ad nobis aspernatur iste nam enim, eius veritatis non excepturi aliquam sed deserunt qui nihil eveniet facilis! Necessitatibus asperiores ut repellendus repudiandae in?
       Ipsum odio minima excepturi eaque laboriosam cupiditate repudiandae dolorem, magnam architecto sint perferendis optio, voluptas eligendi doloribus dignissimos illo quis. Voluptatem odio alias, nesciunt architecto voluptatibus delectus aspernatur suscipit sequi?
       Similique dolore esse tempore eligendi. Quo accusamus veniam similique odio necessitatibus nostrum perspiciatis at corporis autem rem aliquid atque veritatis ducimus praesentium tenetur, doloremque perferendis? Dolorum fugiat tenetur cupiditate cum!
-      <OverlayContainer obfuscate onClose={() => setVisible(false)}>
+      <OverlayContainer obfuscate={args.isModal} onClose={() => setVisible(false)}>
         {visible && (
           <Drawer {...args}>
             {children}

--- a/packages/react-components/src/components/drawer/drawer.tsx
+++ b/packages/react-components/src/components/drawer/drawer.tsx
@@ -124,7 +124,7 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(({
                   className={styles.Header}
                 >
                   <Title responsive={false} level="6" id={titleId}>{title}</Title>
-                  {onClose && <IconButton dimension="small" onClick={onClose} className={styles.CloseButton} icon="xmark" kind="flat" />}
+                  {onClose && <IconButton onClick={onClose} className={styles.CloseButton} icon="xmark" kind="flat" />}
                 </Stack>
               )}
               <AutoFocusInside>

--- a/packages/react-components/src/components/icon/icon.tsx
+++ b/packages/react-components/src/components/icon/icon.tsx
@@ -24,7 +24,7 @@ export type IconProps = SVGAttributes<SVGElement | SVGSVGElement> & {
    * Set the size of the icon. To improve readability at any size, the style of the icon
    * is automatically defined based on the dimension.
    */
-  dimension?: TokensTypes['icon']['size'] | 32 | 40 | 48 | 56;
+  dimension?: TokensTypes['icon']['size'];
   /**
    * Set the style of the icon.
    * The default style is `solid` and outline or duotone icons are available

--- a/packages/react-components/src/components/menu/menu-item/menu-item.tsx
+++ b/packages/react-components/src/components/menu/menu-item/menu-item.tsx
@@ -112,7 +112,7 @@ export const MenuItem = forwardRef(({
         <Icon
           className={styles.IconClass}
           source={icon}
-          dimension={dimension === 'small' ? 14 : 16}
+          dimension={dimension === 'small' ? 12 : 16}
         />
       )}
       <Stack className={styles.DecorationContent} columnGap={16} fill={false} direction="row" horizontalAlign="space-between">

--- a/packages/react-components/src/components/menu/menu.stories.tsx
+++ b/packages/react-components/src/components/menu/menu.stories.tsx
@@ -5,17 +5,7 @@ import { Separator, Chip } from '../..'
 
 export default {
   title: 'Components/Navigation/Menu',
-  component: Menu,
-  argTypes: {
-    dimension: {
-      options: ['small', 'regular'],
-      control: { type: 'radio' }
-    },
-    iconPosition: {
-      options: ['left', 'right'],
-      control: { type: 'radio' }
-    }
-  }
+  component: Menu
 } as ComponentMeta<typeof Menu>
 
 const Template: ComponentStory<typeof Menu> = (args) => (

--- a/packages/react-components/src/components/select/select.module.css
+++ b/packages/react-components/src/components/select/select.module.css
@@ -112,6 +112,7 @@
   border-radius: env(--radius-4);
   pointer-events: none;
   position: absolute;
-  top: calc(var(--field-padding) - calc(var(--field-padding) / 4));
+  top: calc(var(--field-height) / 2);
+  transform: translateY(-50%);
   right: calc(var(--field-padding) - calc(var(--field-padding) / 3));
 }

--- a/packages/react-components/src/components/select/select.tsx
+++ b/packages/react-components/src/components/select/select.tsx
@@ -49,7 +49,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(({
   const seedID = useUIDSeed()
 
   const iconSizes = {
-    small: 14,
+    small: 12,
     regular: 16,
     big: 24
   }

--- a/packages/react-components/src/components/snackbar/snackbar.module.css
+++ b/packages/react-components/src/components/snackbar/snackbar.module.css
@@ -39,6 +39,7 @@
 
 .Icon {
   flex-shrink: 0;
+  flex-grow: 0;
 }
 
 .Action:is(.Action.Action) {

--- a/packages/react-components/src/components/star-meter/star-meter.module.css
+++ b/packages/react-components/src/components/star-meter/star-meter.module.css
@@ -1,16 +1,16 @@
 .StarMeter {
   --star-color: hsl(env(--color-yellow-20));
   --star-dimmed-color: var(--dimmed-2);
-  --icon-size: 18px;
+  --icon-size: env(--icon-size-16);
 
   position: relative;
 
   &[data-star-meter-dimension='small'] {
-    --icon-size: 16px;
+    --icon-size: env(--icon-size-14);
   }
 
   &[data-star-meter-dimension='big'] {
-    --icon-size: 20px;
+    --icon-size: env(--icon-size-24);
   }
 }
 

--- a/packages/react-components/src/components/textfield/textfield.module.css
+++ b/packages/react-components/src/components/textfield/textfield.module.css
@@ -69,8 +69,8 @@
   }
 }
 
-.IconButton.IconButton.IconButton {
-  --x: 19%;
+.IconButton:is(.IconButton) {
+  --x: 25%;
 
   position: absolute;
   top: 50%;

--- a/packages/react-components/src/components/textfield/textfield.stories.tsx
+++ b/packages/react-components/src/components/textfield/textfield.stories.tsx
@@ -90,7 +90,11 @@ Types.argTypes = {
   }
 }
 
-export const Textarea = SingleTemplate.bind({})
+const TextareaTemplate: ComponentStory<typeof Textfield> = (args) => (
+  <Textfield {...args} defaultValue="123123klòasj" placeholder="Placeholder" />
+)
+
+export const Textarea = TextareaTemplate.bind({})
 Textarea.args = {
   disabled: false,
   textarea: true

--- a/packages/react-components/src/components/textfield/textfield.tsx
+++ b/packages/react-components/src/components/textfield/textfield.tsx
@@ -82,14 +82,14 @@ export const Textfield = forwardRef<PrimitiveInputType, TextfieldProps>(({
   )
 
   const iconSizes = {
-    small: 14,
+    small: 12,
     regular: 16,
     big: 24
   }
 
   const actionSizes = {
     small: 'small',
-    regular: 'small',
+    regular: 'regular',
     big: 'big'
   }
 

--- a/packages/react-components/src/components/toggle-button/toggle-button.tsx
+++ b/packages/react-components/src/components/toggle-button/toggle-button.tsx
@@ -77,7 +77,7 @@ export const ToggleButton = forwardRef(({
       const iconSize = {
         big: 24,
         regular: 16,
-        small: 14
+        small: 12
       }
 
       return (<Icon source={icon} dimension={iconSize[dimension] as IconProps['dimension']} />)

--- a/packages/tokens/src/layout/icons.json
+++ b/packages/tokens/src/layout/icons.json
@@ -1,8 +1,8 @@
 {
   "icon": {
     "size": {
-      "14": {
-        "value": 14,
+      "12": {
+        "value": 12,
         "attributes": {
           "category": "size"
         }
@@ -15,6 +15,30 @@
       },
       "24": {
         "value": 24,
+        "attributes": {
+          "category": "size"
+        }
+      },
+      "32": {
+        "value": 32,
+        "attributes": {
+          "category": "size"
+        }
+      },
+      "40": {
+        "value": 40,
+        "attributes": {
+          "category": "size"
+        }
+      },
+      "48": {
+        "value": 48,
+        "attributes": {
+          "category": "size"
+        }
+      },
+      "56": {
+        "value": 56,
         "attributes": {
           "category": "size"
         }


### PR DESCRIPTION
This PR:

- Removes `icon-size-14` token
- Adds `icon-size-12` token
- Adds `icon-size-32` token
- Adds `icon-size-40` token
- Adds `icon-size-48` token
- Adds `icon-size-56` token
- Tweaks icon positioning in small variants