### PR TITLE
style: standardize chip padding

### DIFF
--- a/.changeset/weak-dogs-brake.md
+++ b/.changeset/weak-dogs-brake.md
@@ -1,0 +1,5 @@
+---
+"@wonderflow/react-components": patch
+---
+
+Standardized chip paddings.

--- a/packages/react-components/src/components/chip/chip.module.css
+++ b/packages/react-components/src/components/chip/chip.module.css
@@ -1,5 +1,5 @@
 .Chip {
-  padding: 0 token(--space-8) token(--space-4);
+  padding: token(--space-4) token(--space-8);
   border-radius: token(--radius-48);
   background-color: var(--highlight-gray-background);
   color: var(--highlight-gray-foreground);


### PR DESCRIPTION
Remove top padding so that the vertical padding is the same and the chip content is centered.