### PR TITLE
chore: fix incorrect link

### DIFF
--- a/apps/docs/src/data/components-nav.ts
+++ b/apps/docs/src/data/components-nav.ts
@@ -199,7 +199,7 @@ const ComponentsNav: NavigationMenu = [
     icon: 'compass',
     items: [
       {
-        path: '/get-started/documentation/get-started/accessibility',
+        path: '/get-started/components/navigation/menu',
         label: 'Menu',
         target: '',
       },


### PR DESCRIPTION
Currently the link from the menu points to https://design.wonderflow.ai/get-started/documentation/get-started/accessibility

This fixes the incorrect link.